### PR TITLE
Fix stdout logging and Docker command for JobSpy MCP on Windows

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -30,6 +30,7 @@ const logger = winston.createLogger({
   defaultMeta: { service: 'jobspy-mcp-server' },
   transports: [
     new winston.transports.Console({
+      stderrLevels: ['error', 'warn', 'info', 'debug'],
       format: winston.format.combine(
         winston.format.colorize({ all: true }),
         winston.format.printf(

--- a/src/tools/search-jobs.js
+++ b/src/tools/search-jobs.js
@@ -172,7 +172,7 @@ export function searchJobsHandler(params) {
     logger.info('Validated parameters', { validatedParams });
 
     const args = buildCommandArgs(validatedParams);
-    const cmd = `sudo docker run jobspy ${args.join(' ')}`;
+    const cmd = `docker run --rm jobspy ${args.join(' ')}`;
     logger.info(`Spawning process with args: ${cmd}`);
 
     const timeout = params.timeout || 60000; // Default timeout of 60 seconds

--- a/src/tools/search-jobs.js
+++ b/src/tools/search-jobs.js
@@ -172,7 +172,8 @@ export function searchJobsHandler(params) {
     logger.info('Validated parameters', { validatedParams });
 
     const args = buildCommandArgs(validatedParams);
-    const cmd = `docker run --rm jobspy ${args.join(' ')}`;
+    const dockerCmd = process.env.DOCKER_CMD || 'docker';
+    const cmd = `${dockerCmd} run --rm jobspy ${args.join(' ')}`;
     logger.info(`Spawning process with args: ${cmd}`);
 
     const timeout = params.timeout || 60000; // Default timeout of 60 seconds


### PR DESCRIPTION
Context

I am using this MCP server with Claude Desktop on Windows 11.
While integrating it, I found two issues that break JSON-RPC over stdio and prevent the Docker-based JobSpy integration from working on Windows.

This PR fixes both issues in a minimal and backward-compatible way.

1. Winston logger pollutes the MCP stdio JSON-RPC stream

- Previously, the server used `winston.transports.Console()` with default settings.
- That means `info` / `debug` log messages are written to **stdout**.
- When the MCP server is used over stdio (e.g., with Claude Desktop), stdout must contain only MCP JSON-RPC messages.
- As a result, Claude Desktop received log lines like:

  `2026-03-13 13:20:24 info: Starting JobSpy MCP server...`

  mixed into the JSON-RPC stream, causing JSON parse errors such as:

  > MCP jobspy: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)

Fix

- Update the Winston logger configuration so that all log output is written to **stderr** instead of stdout.
- This keeps stdout clean and reserved for MCP JSON-RPC messages, which is required for stdio transports (Claude Desktop, etc.).

2. `sudo docker run jobspy` is not compatible with Windows

- The job search handler previously executed `sudo docker run jobspy` to invoke the JobSpy Docker image.
- On Windows, `sudo` does not exist, and on most setups it is not needed at all when Docker Desktop is already running.
- This also left containers behind after each request.

Fix

- Replace:

  ```bash
  sudo docker run jobspy
  ```

  with:

  ```bash
  docker run --rm jobspy
  ```

- This makes the handler:

  - work on Windows, macOS and Linux (as long as Docker is running),
  - automatically clean up containers after each run (`--rm`).

Reproduction steps (before this PR)

1. Configure Claude Desktop to use this MCP server over stdio with a config similar to:

   ```json
   {
     "mcpServers": {
       "jobspy": {
         "command": "node",
         "args": [
           "C:\Sandbox-lite\MCP_Tools\jobspy-mcp-server\src\index.js"
         ],
         "env": {
           "ENABLE_SSE": "0",
           "JOBSPY_HOST": "0.0.0.0",
           "JOBSPY_PORT": "9423"
         }
       }
     }
   }
   ```

2. Start the MCP server:

   ```bash
   npm install
   npm start
   ```

3. Open Claude Desktop, start a new chat, and ask it to use the `jobspy` MCP to search for jobs.

Before this PR:

- Winston logs are written to stdout, which corrupts the MCP JSON-RPC stream.
- Claude Desktop shows errors like:

  > MCP jobspy: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)

- On Windows, the job search handler fails because `sudo` is not available.

After this PR:

- Winston logs are written to stderr, leaving stdout clean for MCP JSON-RPC.
- The Docker command `sudo docker run jobspy` is replaced with `docker run --rm jobspy`, which:
  - works on Windows 11 with Docker Desktop,
  - and automatically removes containers after each request.
- Claude Desktop can successfully:
  - load the JobSpy MCP server,
  - list and use its tools,
  - run job search requests end-to-end without JSON parsing errors.

How to use this MCP with Claude Desktop (step-by-step)

1. Clone the repository:

   ```bash
   git clone https://github.com/borgius/jobspy-mcp-server.git
   cd jobspy-mcp-server
   ```

2. Install dependencies:

   ```bash
   npm install
   ```

3. Make sure Docker Desktop is installed and running, and that you have built the `jobspy` image from the JobSpy project.

4. Start the MCP server:

   ```bash
   npm start
   ```

5. Configure Claude Desktop with the following snippet in `claude_desktop_config.json`:

   ```json
   {
     "mcpServers": {
       "jobspy": {
         "command": "node",
         "args": [
           "C:\Sandbox-lite\MCP_Tools\jobspy-mcp-server\src\index.js"
         ],
         "env": {
           "ENABLE_SSE": "0",
           "JOBSPY_HOST": "0.0.0.0",
           "JOBSPY_PORT": "9423"
         }
       }
     }
   }
   ```

6. Restart Claude Desktop and start a new chat. You should now see the `jobspy` MCP tools available and working.